### PR TITLE
バッチ生成スクリプトの引数処理改善とPillow対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
 ```bash
 python -m venv .venv && . .venv/bin/activate
 pip install -r requirements.txt
-python tools/batch_stamp.py dat/top100mountains_v4.csv input_images output_stamps
+# CSVを省略すると dat/top100mountains_v4.csv を使用
+python tools/batch_stamp.py input_images output_stamps
+# もしくは CSV も指定
+# python tools/batch_stamp.py dat/top100mountains_v4.csv input_images output_stamps
 ```
 
 ## GitHub Actions

--- a/tools/batch_stamp.py
+++ b/tools/batch_stamp.py
@@ -128,7 +128,8 @@ def make_stamp(img_pil: Image.Image, mask_pil: Image.Image, name: str = "") -> I
     # テキスト
     if name:
         font = try_load_font(44)
-        tw, th = font.getsize(name)
+        bbox = font.getbbox(name)
+        tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
         text_img = Image.new("RGBA", (tw + 24, th + 12), (0, 0, 0, 0))
         td = ImageDraw.Draw(text_img)
         for dx, dy in [(-2, 0), (2, 0), (0, -2), (0, 2)]:
@@ -214,8 +215,32 @@ def process_folder(in_dir: str, out_dir: str):
             print(f"FAIL: {p} ({e})")
 
 if __name__ == "__main__":
-    csv_path = sys.argv[1] if len(sys.argv) > 1 else "dat/top100mountains_v4.csv"
-    in_dir = sys.argv[2] if len(sys.argv) > 2 else "input_images"
-    out_dir = sys.argv[3] if len(sys.argv) > 3 else "output_stamps"
+    # 引数は以下のいずれかの形式を受け付ける:
+    #   python tools/batch_stamp.py                           (全てデフォルト)
+    #   python tools/batch_stamp.py input_dir output_dir      (CSVはデフォルト)
+    #   python tools/batch_stamp.py csv_path input_dir output_dir
+    args = sys.argv[1:]
+
+    csv_path = "dat/top100mountains_v4.csv"
+    in_dir = "input_images"
+    out_dir = "output_stamps"
+
+    if len(args) == 1:
+        first = args[0]
+        if first.lower().endswith(".csv"):
+            csv_path = first
+        else:
+            in_dir = first
+    elif len(args) == 2:
+        first, second = args
+        if first.lower().endswith(".csv"):
+            csv_path = first
+            in_dir = second
+        else:
+            in_dir = first
+            out_dir = second
+    elif len(args) >= 3:
+        csv_path, in_dir, out_dir = args[:3]
+
     download_mountain_photos(csv_path, in_dir)
     process_folder(in_dir, out_dir)


### PR DESCRIPTION
## 概要
- `tools/batch_stamp.py` のコマンドライン引数を柔軟にし、CSVパス省略時にも実行できるようにしました
- Pillow 10 系で削除された `getsize` を `getbbox` に置き換えました
- README を更新し、新しい実行方法を追記しました

## テスト
- `python tools/batch_stamp.py input_images output_stamps`


------
https://chatgpt.com/codex/tasks/task_e_68a4f5a17d0083308b24262c93115eb3