### PR TITLE
GitHub ActionsのGITHUB_TOKENに書き込み権限を付与

### DIFF
--- a/.github/workflows/batch.yml
+++ b/.github/workflows/batch.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 20 * * *'   # 毎日UTC20:00（JST+9で翌5:00）
 
+permissions:
+  contents: write
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要
- workflowでGITHUB_TOKENのcontents: write権限を設定

## テスト
- `python -m py_compile tools/batch_stamp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4f8037ee48330a523d7f7cc9950a4