### PR TITLE
画像ダウンロード先のディレクトリ指定を修正

### DIFF
--- a/tools/batch_stamp.py
+++ b/tools/batch_stamp.py
@@ -265,6 +265,6 @@ if __name__ == "__main__":
         if len(args) >= 4:
             complete_dir = Path(args[3])
 
-    download_mountain_photos(csv_path, INPUT_DIR)
+    download_mountain_photos(csv_path, in_dir)
     generate_stamps(in_dir, out_dir)
     add_mountain_names(in_dir, out_dir, complete_dir)


### PR DESCRIPTION
## 概要
- 画像ダウンロード処理が常に既定の`input_images`に保存していた問題を修正
- スクリプト実行時に指定した入力ディレクトリへ保存するように変更

## テスト
- `python -m py_compile tools/batch_stamp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a50cb17ba4833085fce65e0f72a64e