### PR TITLE
円枠を太くしシルエットを円内に収める修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 山の写真から白黒のスタンプ風PNGを **無料/CPUのみ** でバッチ生成します。
 - リスト: `dat/top100mountains_v4.csv`
-- 入力: Wikipediaから自動取得し `input_images/` に保存
+- 入力: Wikipediaから自動取得し `input_images/` に保存（生成後も削除されません）
 - 出力: `output_stamps/`（入力と同名のPNG、透過768px）
 - 山名入りスタンプ: `complete_stamp/`
 - 自動化: GitHub Actions（毎日UTC20:00/JST05:00 & 手動実行）
@@ -25,7 +25,7 @@ python tools/batch_stamp.py input_images output_stamps
 ## 仕組み（概要）
 
 * OpenCV(CPU)の Canny + 形態学 + 最大コンポーネントで **山シルエット** 抽出
-* Pillowで **白い円背景と黒い山シルエット** を合成、透過PNGで保存
+* Pillowで **白い円背景と黒い山シルエット** を合成、透過PNGで保存（円枠線は従来の2倍の太さ）
 
 ## 注意
 

--- a/tools/batch_stamp.py
+++ b/tools/batch_stamp.py
@@ -77,7 +77,7 @@ def make_stamp(img_pil: Image.Image, mask_pil: Image.Image, name: str = "") -> I
     draw = ImageDraw.Draw(canvas)
 
     margin = 20
-    border = 12
+    border = 24  # 円枠線を従来の2倍に太くする
     circle_bbox = [margin, margin, size - margin, size - margin]
     draw.ellipse(circle_bbox, fill=(255, 255, 255, 255), outline=(0, 0, 0, 255), width=border)
 
@@ -95,6 +95,10 @@ def make_stamp(img_pil: Image.Image, mask_pil: Image.Image, name: str = "") -> I
               margin + border + (inner_size - new_size[1]) // 2)
     tmp2 = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
     tmp2.paste(silhouette, offset, silhouette.split()[3])
+    # 山のシルエットが円の外にはみ出さないようにクリッピング
+    circle_mask = Image.new("L", canvas.size, 0)
+    ImageDraw.Draw(circle_mask).ellipse(circle_bbox, fill=255)
+    tmp2 = Image.composite(tmp2, Image.new("RGBA", canvas.size, (0, 0, 0, 0)), circle_mask)
     canvas.alpha_composite(tmp2)
 
     if name:


### PR DESCRIPTION
## 概要
- 円枠線を従来の2倍の太さに変更
- 山のシルエットが円の外にはみ出さないようにクリッピング
- 元画像を `input_images/` に保持する旨をREADMEに追記

## テスト
- `python -m py_compile tools/batch_stamp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a50e86b9d083309aa78ae9dafd4dbe