### PR TITLE
入力画像と完成スタンプをコミットするよう修正

### DIFF
--- a/.github/workflows/batch.yml
+++ b/.github/workflows/batch.yml
@@ -38,6 +38,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add output_stamps/*.png || true
-          git commit -m "Add new mountain stamps [skip ci]" || echo "No changes to commit"
-          git push || echo "Nothing to push"
+          git add input_images/* output_stamps/*.png complete_stamp/* || true
+          git commit -m "山のスタンプを追加 [skip ci]" || echo "変更はありません"
+          git push || echo "変更はありません"


### PR DESCRIPTION
## 概要
- ワークフローで入力画像と完成スタンプもコミットするよう修正

## テスト
- `python tools/batch_stamp.py /tmp/test.csv /tmp/input_images /tmp/output_stamps /tmp/complete_stamp` （403 Forbidden により失敗）

------
https://chatgpt.com/codex/tasks/task_e_68a51096c91483309d17d40e5e780302