### PR TITLE
網掛けと輪郭強調でスタンプ生成を改良

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mountain Stamps (free, CPU-only, batch)
 
-山の写真から白黒のスタンプ風PNGを **無料/CPUのみ** でバッチ生成します。
+山の写真から白黒のスタンプ風PNGを **無料/CPUのみ** でバッチ生成します。網掛けによる陰影と輪郭強調、かすれ効果でリアルなスタンプ感を再現します。
 - リスト: `dat/top100mountains_v4.csv`
 - 入力: Wikipediaから自動取得し `input_images/` に保存（生成後も削除されません）
 - 出力: `output_stamps/`（入力と同名のPNG、透過768px）
@@ -25,7 +25,7 @@ python tools/batch_stamp.py input_images output_stamps
 ## 仕組み（概要）
 
 * OpenCV(CPU)の Canny + 形態学 + 最大コンポーネントで **山シルエット** 抽出
-* Pillowで **白い円背景と黒い山シルエット** を合成、透過PNGで保存（円枠線は従来の2倍の太さ）
+* Pillowで **白い円背景と網掛け・輪郭強調した山シルエット** を合成し、ランダムなかすれを加えた透過PNGを生成（円枠線は従来の2倍の太さ）
 
 ## 注意
 

--- a/tools/batch_stamp.py
+++ b/tools/batch_stamp.py
@@ -1,12 +1,13 @@
 import sys, csv
 from pathlib import Path
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFont, ImageFilter, ImageOps
 import numpy as np
 import cv2
 from urllib.request import urlopen, Request
 from urllib.parse import quote, urlparse, unquote
 import json
 import time
+import random
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 INPUT_DIR = BASE_DIR / "input_images"
@@ -98,18 +99,47 @@ def make_stamp(img_pil: Image.Image, mask_pil: Image.Image, name: str = "") -> I
     mask_sq = mask_pil.resize(new_size, Image.LANCZOS)
     m = mask_sq.convert("L").point(lambda v: 255 if v > 80 else 0)
 
-    sil_layer = Image.new("RGBA", new_size, (0, 0, 0, 255))
-    silhouette = Image.composite(sil_layer, Image.new("RGBA", new_size, (0, 0, 0, 0)), m)
+    # --- 網掛けと輪郭強調によるシルエット生成 ---
+    # グレースケール化してディザ処理を適用
+    gray = img_sq.convert("L")
+    dither = gray.convert("1")  # Floyd-Steinberg ディザ
+    dither = dither.convert("L")
+    halftone = ImageOps.colorize(dither, black="black", white="white").convert("RGBA")
+    halftone.putalpha(m)
 
+    # 輪郭線を抽出して強調
+    mask_np = np.array(m)
+    edges = cv2.Canny(mask_np, 80, 160)
+    edges = cv2.dilate(edges, np.ones((3, 3), np.uint8), 1)
+    edge_img = Image.fromarray(edges)
+    edge_rgba = Image.new("RGBA", new_size, (0, 0, 0, 255))
+    edge_rgba.putalpha(edge_img)
+
+    # キャンバスへ合成
     offset = (margin + border + (inner_size - new_size[0]) // 2,
               margin + border + (inner_size - new_size[1]) // 2)
     tmp2 = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
-    tmp2.paste(silhouette, offset, silhouette.split()[3])
+    tmp2.paste(halftone, offset, halftone.split()[3])
+    tmp2.paste(edge_rgba, offset, edge_rgba.split()[3])
+
     # 山のシルエットが円の外にはみ出さないようにクリッピング
     circle_mask = Image.new("L", canvas.size, 0)
     ImageDraw.Draw(circle_mask).ellipse(circle_bbox, fill=255)
     tmp2 = Image.composite(tmp2, Image.new("RGBA", canvas.size, (0, 0, 0, 0)), circle_mask)
     canvas.alpha_composite(tmp2)
+
+    # --- かすれ・インクのにじみを追加 ---
+    smudge = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
+    sdraw = ImageDraw.Draw(smudge)
+    for _ in range(120):
+        r = random.randint(1, 4)
+        x = random.randint(circle_bbox[0], circle_bbox[2])
+        y = random.randint(circle_bbox[1], circle_bbox[3])
+        alpha = random.randint(20, 60)
+        sdraw.ellipse((x - r, y - r, x + r, y + r), fill=(0, 0, 0, alpha))
+    smudge = smudge.filter(ImageFilter.GaussianBlur(0.8))
+    smudge = Image.composite(smudge, Image.new("RGBA", canvas.size, (0, 0, 0, 0)), circle_mask)
+    canvas.alpha_composite(smudge)
 
     if name:
         try:


### PR DESCRIPTION
## 概要
- 画像のディザ処理による網掛けで陰影を再現
- 輪郭線の強調とランダムなかすれ表現を追加
- README を更新し新機能を説明

## テスト
- `python -m py_compile tools/batch_stamp.py`
- スタンプ生成関数で `test_stamp.png` を生成して動作確認（後に削除）

------
https://chatgpt.com/codex/tasks/task_e_68a52493a61883309562912586925628