### PR TITLE
欠損スタンプ生成スクリプトを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ pip install -r requirements.txt
 python tools/batch_stamp.py input_images output_stamps
 # もしくは CSV も指定
 # python tools/batch_stamp.py dat/top100mountains_v4.csv input_images output_stamps
+# 既に input_images に画像があり、output_stamps に無いスタンプのみ生成する場合
+python tools/generate_missing_stamps.py
 ```
 
 ## GitHub Actions

--- a/tools/generate_missing_stamps.py
+++ b/tools/generate_missing_stamps.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""output_stamps に存在しないスタンプのみ生成する補助スクリプト."""
+from pathlib import Path
+
+from batch_stamp import INPUT_DIR, OUTPUT_DIR, generate_stamps
+
+
+def main() -> None:
+    before = set(Path(OUTPUT_DIR).glob("*.png"))
+    generate_stamps(INPUT_DIR, OUTPUT_DIR)
+    after = set(Path(OUTPUT_DIR).glob("*.png"))
+    added = len(after) - len(before)
+    print(f"{added} 件のスタンプを生成しました。")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要
- output_stampsに存在しないスタンプだけを追加生成するスクリプトを作成
- READMEに新スクリプトの利用方法を追記

## テスト
- `python tools/generate_missing_stamps.py`


------
https://chatgpt.com/codex/tasks/task_e_68a57edf08b88330add650abb306a583